### PR TITLE
deps: upgrade deps to `0.96.1`

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "mira-v1-ts": "file:..",
-    "fuels": "^0.96.0",
+    "fuels": "^0.96.1",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "envalid": "^8.0.0",

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -18,14 +18,14 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       fuels:
-        specifier: ^0.96.0
-        version: 0.96.0
+        specifier: ^0.96.1
+        version: 0.96.1
       inquirer:
         specifier: ^10.1.0
         version: 10.1.2
       mira-v1-ts:
         specifier: file:..
-        version: mira-dex-ts@file:..(fuels@0.96.0)
+        version: mira-dex-ts@file:..(fuels@0.96.1)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.14.11)(typescript@5.2.2)
@@ -328,69 +328,69 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fuel-ts/abi-coder@0.96.0':
-    resolution: {integrity: sha512-8l1O0jkSHHTg7vE7Bq6lIEICskE/hSeyhB+q3ppxbqnr7KNObiPuTxrOK7TDrGUXsxOXk5g65hN1f//aS9HHSA==}
+  '@fuel-ts/abi-coder@0.96.1':
+    resolution: {integrity: sha512-czJxFPirhSO6ayshu9Cr5AmED/IprQ8h1igwlcSHFr5jR+l46bLdlsXsWiUwe7vyvZCpOnxkN/XZYkmQyNxKNg==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/abi-typegen@0.96.0':
-    resolution: {integrity: sha512-EFWUMa+aKMvgZSPc7we0exrfp9qKbw6E+CSlGUYy1JZBZwaaBHsRrQ2EGL9d9q6doWD4VamV+y9Fgj6MYeuGkQ==}
+  '@fuel-ts/abi-typegen@0.96.1':
+    resolution: {integrity: sha512-vRJnAQ9sxkKuUQ2fkxntPm/679grxgwSf54O7vgDeXuXqQx/4XeylpExjH0/nZzEM5al+muw4rg9WwmKulkcZA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     hasBin: true
 
-  '@fuel-ts/account@0.96.0':
-    resolution: {integrity: sha512-zpcpf4NR9vMcHoAfpXgp7SAqHf8hmRgtWGuLReqQnqcJz2g14pF7aIue+bF6kLuBf3o0YrINMPkuFlzLBgxBFQ==}
+  '@fuel-ts/account@0.96.1':
+    resolution: {integrity: sha512-i9InTebg3/buKXNJZpKBhxGMBC3MKpk905Uiv2CvTmldyPVgnZV/jY/b63jlfdEWyP5yVkr5/tzo7QaPKpfnMA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/address@0.96.0':
-    resolution: {integrity: sha512-IU7bVyqjQnHJmnqApbEkAGwvEwImc/QoCCciw3KhkiV4OP/LneOZvOtLKMAWkorBcNeAnw6U1sIRIY8jYHGIYw==}
+  '@fuel-ts/address@0.96.1':
+    resolution: {integrity: sha512-PCuC8oojoWLhh0+boitaP90/Z3iSfEXZR8v1JCEfoLZIkvCq6EGKtiY0KvcNkPozHOHmmT34w/1CS6qHOoCBNA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/contract@0.96.0':
-    resolution: {integrity: sha512-HlMtR+MVUGgQby6NU5/ezO5Li8zfjYrezvaAlVoJtm68r2QDZkeQId4JtD2za7Z1Im6A3eAm4nk9gUIHo6eluw==}
+  '@fuel-ts/contract@0.96.1':
+    resolution: {integrity: sha512-shwNMHFZ7vr5QJsfVQ6aLd1ms88f3ZagrsNLqNz1Txhz/5KVgYyJaxfp7tUc4WZFpR67+W1zeIqx8ZNHVhck3g==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/crypto@0.96.0':
-    resolution: {integrity: sha512-Vl76bhtQj3HliXwm3ihgh2zsIK1jsY/eX8XdgCoc8MmQxureNLdbuxv/PKuqRNcUCWkMdhKj11fitwzGVs5VRA==}
+  '@fuel-ts/crypto@0.96.1':
+    resolution: {integrity: sha512-OrAZPZtm8HQouzip621/ci47PeTS06QegGdz7MeN6wK4yeCbJmlRQ1WE9S3iclb3p+VLF0RtbecEbHQfsNgsnA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/errors@0.96.0':
-    resolution: {integrity: sha512-PXR+gaa8UNIYJuzs/doDLwPNyqU1ctp691XVhWS+usRRqiLPgcS2+0rUKF2lr5kdfH7RWEdzU/muymVOJBpOWA==}
+  '@fuel-ts/errors@0.96.1':
+    resolution: {integrity: sha512-Xtso5v4a3UUvnMaOSDhMRlkb9LxLyCyC/1/RY7fZZ035ttscy6dNMuiD/iSptJ5pHklJ5R4rCPdOL5EKpgOaMA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/hasher@0.96.0':
-    resolution: {integrity: sha512-Zo53yBx1WHbm0j6h5F1j/drDv1yfxW3NLovJFIL4PBRObrU/DlWtiBufkAMWZa1q3IIX1zji8oTIf/7zPIDJkw==}
+  '@fuel-ts/hasher@0.96.1':
+    resolution: {integrity: sha512-7z4cah+5TOcCBA2Wgvje1L7wVTahiFLb9IUpRXRMVGXwaqsbV/wUNcyuc1mhPh/JKLgcOe+OqsrpcYD2dg2rpg==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/interfaces@0.96.0':
-    resolution: {integrity: sha512-/9hhmnokFvELhsufPMNuSVc+q2FueGDEPQ2AMOrgbnefBvB6y8ON5t7yjapQo/s8BVxUWIdvlnCS2Cn9OUJ/iQ==}
+  '@fuel-ts/interfaces@0.96.1':
+    resolution: {integrity: sha512-mZ3sDHJml5AtLRSmGWo5rbU9//3oKDhAeiFealajcPaVztAAnaKnA5a19dd4ITbjZb2q3e2lQ7zX8iAXgHUwYA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/math@0.96.0':
-    resolution: {integrity: sha512-DZW4kEAR5BbTuWAonakaigCpW9nHuVuLXTwqMUyYbIRy/mYzAA2ui713F/Yn67GBCVRez3bOXzUc7TH2QUNKRg==}
+  '@fuel-ts/math@0.96.1':
+    resolution: {integrity: sha512-AZUChguQmE1ILYbcc6SOTjFJIUkGzD3Z6yHgvO4tszn2QS/jVTSAZKVx653J5u9m/Xn/WthwR35l1GbwXMwB4g==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/merkle@0.96.0':
-    resolution: {integrity: sha512-ZIWq8qLx2BHussNp1AyTx5MZY7ersgPrWrVq5LULgUZaE4z8nY9DNSyLblwTlET3cs+u4umNRkjrm0AEkvyGpA==}
+  '@fuel-ts/merkle@0.96.1':
+    resolution: {integrity: sha512-7cLbxYG5berKSK+wPKrkbB9dZ6akOm7C1Ij4iwYXOxQWlmXY62mjSY5Tl1PPyDBSdRqBtqxW0xYUGIzZl2A/3g==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/program@0.96.0':
-    resolution: {integrity: sha512-OXtKOm0zsDl7U9NrBFr8Q92piH87OAZMDBpvCJesv8IGXqLR6+O0MhNa8RDls5gIf5pgGyd1LyWzfTHOdiRv9A==}
+  '@fuel-ts/program@0.96.1':
+    resolution: {integrity: sha512-tA2YvcIdlDQLKeOOfoTyfI3LRQZiqsHi5rFaGbOsjEQvyNQBdXa92vMMFW0dFNWXqOPLjTmYNWqp0xsMuikbsA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/script@0.96.0':
-    resolution: {integrity: sha512-3X3G+vMLjWQfIP2TY+riHYJ5jJV6/ii7yRfkHyKJ0ntnY59kLVfsA97BkXVAe1GFdV0Hw8xXRPhDlCPIuABTYQ==}
+  '@fuel-ts/script@0.96.1':
+    resolution: {integrity: sha512-N/N3I3xjDI1+9XcCrYTWapF0iBbdvtBxUUUZxn5S5GuIXuTCK6UfQLrRciuCHK5QiHVwFmQjlki+ozJfI+4UbQ==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/transactions@0.96.0':
-    resolution: {integrity: sha512-hLRgfO+DlpJHWBDcuCW9vh8yh8kQh/nuhtK/VlfknfITFR+gCcnJCqtEtP95qOwElqkiRBm9+VQJBK3qATWPVA==}
+  '@fuel-ts/transactions@0.96.1':
+    resolution: {integrity: sha512-yPQBzMeFIzNBLUZigaf4q0hETO8AH8Evt6ZvpWrYhjYz2WfEpfNDpuhIHRwsMfJRbxz2vhQ51AzkRqpH0b2GMQ==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/utils@0.96.0':
-    resolution: {integrity: sha512-ME5xLtXocxszic9kIfT51oYAeJdeaCSlvBhAyFzAAyLlbkcL/pPU1d35Dm0ghyxMTEAOO/11CXMBPESIdM54aw==}
+  '@fuel-ts/utils@0.96.1':
+    resolution: {integrity: sha512-XXZNEUPf7qtKpVO3ak2CSroBYEKh1Gne1zlmVSNUoVPqQvglcu0I2pu/QmVnZBN4m3yVSyHUoWR2Kbo8/Dh7sA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/versions@0.96.0':
-    resolution: {integrity: sha512-uffrtpkCguzsVkCLW7tuZG1BwNu69LCjy8sO831VcpZsDRzIy3qO/om9X17W2HTJXxSS+25ok4t7fThIF+w6Gg==}
+  '@fuel-ts/versions@0.96.1':
+    resolution: {integrity: sha512-C//ZT7U68Gksz9PzUJVzdzUARK7mfXf3MsF5ZqZaMegkE2tCy+twjy8PBdeVserY0uX6mEHRJyZJwcspk34ixg==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     hasBin: true
 
@@ -804,8 +804,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  fuels@0.96.0:
-    resolution: {integrity: sha512-T3MhpoOPA5VBc7Vw+UJBZLUB0nN73jUjueifzKYUeRhTTPypkTYZ69r8S4825/qsay8kKtingHPcxcGhccHBww==}
+  fuels@0.96.1:
+    resolution: {integrity: sha512-BquRIJ0qHNKwhqBTNa6X4aghqhCj1Qz0jM+P0bziXAEk7gVJJZWRz10jCcAgZVeEb4AMdZLDsnNzKJ51GH8IvQ==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     hasBin: true
 
@@ -917,7 +917,7 @@ packages:
   mira-dex-ts@file:..:
     resolution: {directory: .., type: directory}
     peerDependencies:
-      fuels: ^0.96.0
+      fuels: ^0.96.1
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -1350,22 +1350,22 @@ snapshots:
   '@esbuild/win32-x64@0.24.0':
     optional: true
 
-  '@fuel-ts/abi-coder@0.96.0':
+  '@fuel-ts/abi-coder@0.96.1':
     dependencies:
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       type-fest: 4.26.1
 
-  '@fuel-ts/abi-typegen@0.96.0':
+  '@fuel-ts/abi-typegen@0.96.1':
     dependencies:
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/utils': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       commander: 12.1.0
       glob: 10.4.5
       handlebars: 4.7.8
@@ -1373,19 +1373,19 @@ snapshots:
       ramda: 0.30.1
       rimraf: 5.0.10
 
-  '@fuel-ts/account@0.96.0':
+  '@fuel-ts/account@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/merkle': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       '@fuels/vm-asm': 0.58.0
       '@noble/curves': 1.6.0
       events: 3.3.0
@@ -1396,114 +1396,114 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@fuel-ts/address@0.96.0':
+  '@fuel-ts/address@0.96.1':
     dependencies:
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       '@noble/hashes': 1.5.0
       bech32: 2.0.0
 
-  '@fuel-ts/contract@0.96.0':
+  '@fuel-ts/contract@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/account': 0.96.0
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/merkle': 0.96.0
-      '@fuel-ts/program': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       '@fuels/vm-asm': 0.58.0
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
 
-  '@fuel-ts/crypto@0.96.0':
+  '@fuel-ts/crypto@0.96.1':
     dependencies:
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       '@noble/hashes': 1.5.0
 
-  '@fuel-ts/errors@0.96.0':
+  '@fuel-ts/errors@0.96.1':
     dependencies:
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/versions': 0.96.1
 
-  '@fuel-ts/hasher@0.96.0':
+  '@fuel-ts/hasher@0.96.1':
     dependencies:
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       '@noble/hashes': 1.5.0
 
-  '@fuel-ts/interfaces@0.96.0': {}
+  '@fuel-ts/interfaces@0.96.1': {}
 
-  '@fuel-ts/math@0.96.0':
+  '@fuel-ts/math@0.96.1':
     dependencies:
-      '@fuel-ts/errors': 0.96.0
+      '@fuel-ts/errors': 0.96.1
       '@types/bn.js': 5.1.6
       bn.js: 5.2.1
 
-  '@fuel-ts/merkle@0.96.0':
+  '@fuel-ts/merkle@0.96.1':
     dependencies:
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/math': 0.96.0
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/math': 0.96.1
 
-  '@fuel-ts/program@0.96.0':
+  '@fuel-ts/program@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/account': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       '@fuels/vm-asm': 0.58.0
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
 
-  '@fuel-ts/script@0.96.0':
+  '@fuel-ts/script@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/account': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/program': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
     transitivePeerDependencies:
       - encoding
 
-  '@fuel-ts/transactions@0.96.0':
+  '@fuel-ts/transactions@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
 
-  '@fuel-ts/utils@0.96.0':
+  '@fuel-ts/utils@0.96.1':
     dependencies:
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       fflate: 0.8.2
 
-  '@fuel-ts/versions@0.96.0':
+  '@fuel-ts/versions@0.96.1':
     dependencies:
       chalk: 4.1.2
       cli-table: 0.3.11
@@ -1932,24 +1932,24 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fuels@0.96.0:
+  fuels@0.96.1:
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/abi-typegen': 0.96.0
-      '@fuel-ts/account': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/contract': 0.96.0
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/merkle': 0.96.0
-      '@fuel-ts/program': 0.96.0
-      '@fuel-ts/script': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/abi-typegen': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/contract': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/script': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       bundle-require: 5.0.0(esbuild@0.24.0)
       chalk: 4.1.2
       chokidar: 3.6.0
@@ -2070,9 +2070,9 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mira-dex-ts@file:..(fuels@0.96.0):
+  mira-dex-ts@file:..(fuels@0.96.1):
     dependencies:
-      fuels: 0.96.0
+      fuels: 0.96.1
 
   mkdirp@0.5.6:
     dependencies:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "miradeployer@gmail.com",
   "license": "ISC",
   "peerDependencies": {
-    "fuels": "^0.96.0"
+    "fuels": "^0.96.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       fuels:
-        specifier: ^0.96.0
-        version: 0.96.0
+        specifier: ^0.96.1
+        version: 0.96.1
     devDependencies:
       '@types/jest':
         specifier: ^29.5.13
@@ -344,69 +344,69 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fuel-ts/abi-coder@0.96.0':
-    resolution: {integrity: sha512-8l1O0jkSHHTg7vE7Bq6lIEICskE/hSeyhB+q3ppxbqnr7KNObiPuTxrOK7TDrGUXsxOXk5g65hN1f//aS9HHSA==}
+  '@fuel-ts/abi-coder@0.96.1':
+    resolution: {integrity: sha512-czJxFPirhSO6ayshu9Cr5AmED/IprQ8h1igwlcSHFr5jR+l46bLdlsXsWiUwe7vyvZCpOnxkN/XZYkmQyNxKNg==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/abi-typegen@0.96.0':
-    resolution: {integrity: sha512-EFWUMa+aKMvgZSPc7we0exrfp9qKbw6E+CSlGUYy1JZBZwaaBHsRrQ2EGL9d9q6doWD4VamV+y9Fgj6MYeuGkQ==}
+  '@fuel-ts/abi-typegen@0.96.1':
+    resolution: {integrity: sha512-vRJnAQ9sxkKuUQ2fkxntPm/679grxgwSf54O7vgDeXuXqQx/4XeylpExjH0/nZzEM5al+muw4rg9WwmKulkcZA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     hasBin: true
 
-  '@fuel-ts/account@0.96.0':
-    resolution: {integrity: sha512-zpcpf4NR9vMcHoAfpXgp7SAqHf8hmRgtWGuLReqQnqcJz2g14pF7aIue+bF6kLuBf3o0YrINMPkuFlzLBgxBFQ==}
+  '@fuel-ts/account@0.96.1':
+    resolution: {integrity: sha512-i9InTebg3/buKXNJZpKBhxGMBC3MKpk905Uiv2CvTmldyPVgnZV/jY/b63jlfdEWyP5yVkr5/tzo7QaPKpfnMA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/address@0.96.0':
-    resolution: {integrity: sha512-IU7bVyqjQnHJmnqApbEkAGwvEwImc/QoCCciw3KhkiV4OP/LneOZvOtLKMAWkorBcNeAnw6U1sIRIY8jYHGIYw==}
+  '@fuel-ts/address@0.96.1':
+    resolution: {integrity: sha512-PCuC8oojoWLhh0+boitaP90/Z3iSfEXZR8v1JCEfoLZIkvCq6EGKtiY0KvcNkPozHOHmmT34w/1CS6qHOoCBNA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/contract@0.96.0':
-    resolution: {integrity: sha512-HlMtR+MVUGgQby6NU5/ezO5Li8zfjYrezvaAlVoJtm68r2QDZkeQId4JtD2za7Z1Im6A3eAm4nk9gUIHo6eluw==}
+  '@fuel-ts/contract@0.96.1':
+    resolution: {integrity: sha512-shwNMHFZ7vr5QJsfVQ6aLd1ms88f3ZagrsNLqNz1Txhz/5KVgYyJaxfp7tUc4WZFpR67+W1zeIqx8ZNHVhck3g==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/crypto@0.96.0':
-    resolution: {integrity: sha512-Vl76bhtQj3HliXwm3ihgh2zsIK1jsY/eX8XdgCoc8MmQxureNLdbuxv/PKuqRNcUCWkMdhKj11fitwzGVs5VRA==}
+  '@fuel-ts/crypto@0.96.1':
+    resolution: {integrity: sha512-OrAZPZtm8HQouzip621/ci47PeTS06QegGdz7MeN6wK4yeCbJmlRQ1WE9S3iclb3p+VLF0RtbecEbHQfsNgsnA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/errors@0.96.0':
-    resolution: {integrity: sha512-PXR+gaa8UNIYJuzs/doDLwPNyqU1ctp691XVhWS+usRRqiLPgcS2+0rUKF2lr5kdfH7RWEdzU/muymVOJBpOWA==}
+  '@fuel-ts/errors@0.96.1':
+    resolution: {integrity: sha512-Xtso5v4a3UUvnMaOSDhMRlkb9LxLyCyC/1/RY7fZZ035ttscy6dNMuiD/iSptJ5pHklJ5R4rCPdOL5EKpgOaMA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/hasher@0.96.0':
-    resolution: {integrity: sha512-Zo53yBx1WHbm0j6h5F1j/drDv1yfxW3NLovJFIL4PBRObrU/DlWtiBufkAMWZa1q3IIX1zji8oTIf/7zPIDJkw==}
+  '@fuel-ts/hasher@0.96.1':
+    resolution: {integrity: sha512-7z4cah+5TOcCBA2Wgvje1L7wVTahiFLb9IUpRXRMVGXwaqsbV/wUNcyuc1mhPh/JKLgcOe+OqsrpcYD2dg2rpg==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/interfaces@0.96.0':
-    resolution: {integrity: sha512-/9hhmnokFvELhsufPMNuSVc+q2FueGDEPQ2AMOrgbnefBvB6y8ON5t7yjapQo/s8BVxUWIdvlnCS2Cn9OUJ/iQ==}
+  '@fuel-ts/interfaces@0.96.1':
+    resolution: {integrity: sha512-mZ3sDHJml5AtLRSmGWo5rbU9//3oKDhAeiFealajcPaVztAAnaKnA5a19dd4ITbjZb2q3e2lQ7zX8iAXgHUwYA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/math@0.96.0':
-    resolution: {integrity: sha512-DZW4kEAR5BbTuWAonakaigCpW9nHuVuLXTwqMUyYbIRy/mYzAA2ui713F/Yn67GBCVRez3bOXzUc7TH2QUNKRg==}
+  '@fuel-ts/math@0.96.1':
+    resolution: {integrity: sha512-AZUChguQmE1ILYbcc6SOTjFJIUkGzD3Z6yHgvO4tszn2QS/jVTSAZKVx653J5u9m/Xn/WthwR35l1GbwXMwB4g==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/merkle@0.96.0':
-    resolution: {integrity: sha512-ZIWq8qLx2BHussNp1AyTx5MZY7ersgPrWrVq5LULgUZaE4z8nY9DNSyLblwTlET3cs+u4umNRkjrm0AEkvyGpA==}
+  '@fuel-ts/merkle@0.96.1':
+    resolution: {integrity: sha512-7cLbxYG5berKSK+wPKrkbB9dZ6akOm7C1Ij4iwYXOxQWlmXY62mjSY5Tl1PPyDBSdRqBtqxW0xYUGIzZl2A/3g==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/program@0.96.0':
-    resolution: {integrity: sha512-OXtKOm0zsDl7U9NrBFr8Q92piH87OAZMDBpvCJesv8IGXqLR6+O0MhNa8RDls5gIf5pgGyd1LyWzfTHOdiRv9A==}
+  '@fuel-ts/program@0.96.1':
+    resolution: {integrity: sha512-tA2YvcIdlDQLKeOOfoTyfI3LRQZiqsHi5rFaGbOsjEQvyNQBdXa92vMMFW0dFNWXqOPLjTmYNWqp0xsMuikbsA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/script@0.96.0':
-    resolution: {integrity: sha512-3X3G+vMLjWQfIP2TY+riHYJ5jJV6/ii7yRfkHyKJ0ntnY59kLVfsA97BkXVAe1GFdV0Hw8xXRPhDlCPIuABTYQ==}
+  '@fuel-ts/script@0.96.1':
+    resolution: {integrity: sha512-N/N3I3xjDI1+9XcCrYTWapF0iBbdvtBxUUUZxn5S5GuIXuTCK6UfQLrRciuCHK5QiHVwFmQjlki+ozJfI+4UbQ==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/transactions@0.96.0':
-    resolution: {integrity: sha512-hLRgfO+DlpJHWBDcuCW9vh8yh8kQh/nuhtK/VlfknfITFR+gCcnJCqtEtP95qOwElqkiRBm9+VQJBK3qATWPVA==}
+  '@fuel-ts/transactions@0.96.1':
+    resolution: {integrity: sha512-yPQBzMeFIzNBLUZigaf4q0hETO8AH8Evt6ZvpWrYhjYz2WfEpfNDpuhIHRwsMfJRbxz2vhQ51AzkRqpH0b2GMQ==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/utils@0.96.0':
-    resolution: {integrity: sha512-ME5xLtXocxszic9kIfT51oYAeJdeaCSlvBhAyFzAAyLlbkcL/pPU1d35Dm0ghyxMTEAOO/11CXMBPESIdM54aw==}
+  '@fuel-ts/utils@0.96.1':
+    resolution: {integrity: sha512-XXZNEUPf7qtKpVO3ak2CSroBYEKh1Gne1zlmVSNUoVPqQvglcu0I2pu/QmVnZBN4m3yVSyHUoWR2Kbo8/Dh7sA==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
 
-  '@fuel-ts/versions@0.96.0':
-    resolution: {integrity: sha512-uffrtpkCguzsVkCLW7tuZG1BwNu69LCjy8sO831VcpZsDRzIy3qO/om9X17W2HTJXxSS+25ok4t7fThIF+w6Gg==}
+  '@fuel-ts/versions@0.96.1':
+    resolution: {integrity: sha512-C//ZT7U68Gksz9PzUJVzdzUARK7mfXf3MsF5ZqZaMegkE2tCy+twjy8PBdeVserY0uX6mEHRJyZJwcspk34ixg==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     hasBin: true
 
@@ -929,8 +929,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  fuels@0.96.0:
-    resolution: {integrity: sha512-T3MhpoOPA5VBc7Vw+UJBZLUB0nN73jUjueifzKYUeRhTTPypkTYZ69r8S4825/qsay8kKtingHPcxcGhccHBww==}
+  fuels@0.96.1:
+    resolution: {integrity: sha512-BquRIJ0qHNKwhqBTNa6X4aghqhCj1Qz0jM+P0bziXAEk7gVJJZWRz10jCcAgZVeEb4AMdZLDsnNzKJ51GH8IvQ==}
     engines: {node: ^18.20.3 || ^20.0.0 || ^22.0.0}
     hasBin: true
 
@@ -2008,22 +2008,22 @@ snapshots:
   '@esbuild/win32-x64@0.24.0':
     optional: true
 
-  '@fuel-ts/abi-coder@0.96.0':
+  '@fuel-ts/abi-coder@0.96.1':
     dependencies:
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       type-fest: 4.26.1
 
-  '@fuel-ts/abi-typegen@0.96.0':
+  '@fuel-ts/abi-typegen@0.96.1':
     dependencies:
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/utils': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       commander: 12.1.0
       glob: 10.4.5
       handlebars: 4.7.8
@@ -2031,19 +2031,19 @@ snapshots:
       ramda: 0.30.1
       rimraf: 5.0.10
 
-  '@fuel-ts/account@0.96.0':
+  '@fuel-ts/account@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/merkle': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       '@fuels/vm-asm': 0.58.0
       '@noble/curves': 1.6.0
       events: 3.3.0
@@ -2054,114 +2054,114 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@fuel-ts/address@0.96.0':
+  '@fuel-ts/address@0.96.1':
     dependencies:
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       '@noble/hashes': 1.5.0
       bech32: 2.0.0
 
-  '@fuel-ts/contract@0.96.0':
+  '@fuel-ts/contract@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/account': 0.96.0
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/merkle': 0.96.0
-      '@fuel-ts/program': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       '@fuels/vm-asm': 0.58.0
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
 
-  '@fuel-ts/crypto@0.96.0':
+  '@fuel-ts/crypto@0.96.1':
     dependencies:
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       '@noble/hashes': 1.5.0
 
-  '@fuel-ts/errors@0.96.0':
+  '@fuel-ts/errors@0.96.1':
     dependencies:
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/versions': 0.96.1
 
-  '@fuel-ts/hasher@0.96.0':
+  '@fuel-ts/hasher@0.96.1':
     dependencies:
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       '@noble/hashes': 1.5.0
 
-  '@fuel-ts/interfaces@0.96.0': {}
+  '@fuel-ts/interfaces@0.96.1': {}
 
-  '@fuel-ts/math@0.96.0':
+  '@fuel-ts/math@0.96.1':
     dependencies:
-      '@fuel-ts/errors': 0.96.0
+      '@fuel-ts/errors': 0.96.1
       '@types/bn.js': 5.1.6
       bn.js: 5.2.1
 
-  '@fuel-ts/merkle@0.96.0':
+  '@fuel-ts/merkle@0.96.1':
     dependencies:
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/math': 0.96.0
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/math': 0.96.1
 
-  '@fuel-ts/program@0.96.0':
+  '@fuel-ts/program@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/account': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
       '@fuels/vm-asm': 0.58.0
       ramda: 0.30.1
     transitivePeerDependencies:
       - encoding
 
-  '@fuel-ts/script@0.96.0':
+  '@fuel-ts/script@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/account': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/program': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
     transitivePeerDependencies:
       - encoding
 
-  '@fuel-ts/transactions@0.96.0':
+  '@fuel-ts/transactions@0.96.1':
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/utils': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/utils': 0.96.1
 
-  '@fuel-ts/utils@0.96.0':
+  '@fuel-ts/utils@0.96.1':
     dependencies:
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       fflate: 0.8.2
 
-  '@fuel-ts/versions@0.96.0':
+  '@fuel-ts/versions@0.96.1':
     dependencies:
       chalk: 4.1.2
       cli-table: 0.3.11
@@ -2816,24 +2816,24 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fuels@0.96.0:
+  fuels@0.96.1:
     dependencies:
-      '@fuel-ts/abi-coder': 0.96.0
-      '@fuel-ts/abi-typegen': 0.96.0
-      '@fuel-ts/account': 0.96.0
-      '@fuel-ts/address': 0.96.0
-      '@fuel-ts/contract': 0.96.0
-      '@fuel-ts/crypto': 0.96.0
-      '@fuel-ts/errors': 0.96.0
-      '@fuel-ts/hasher': 0.96.0
-      '@fuel-ts/interfaces': 0.96.0
-      '@fuel-ts/math': 0.96.0
-      '@fuel-ts/merkle': 0.96.0
-      '@fuel-ts/program': 0.96.0
-      '@fuel-ts/script': 0.96.0
-      '@fuel-ts/transactions': 0.96.0
-      '@fuel-ts/utils': 0.96.0
-      '@fuel-ts/versions': 0.96.0
+      '@fuel-ts/abi-coder': 0.96.1
+      '@fuel-ts/abi-typegen': 0.96.1
+      '@fuel-ts/account': 0.96.1
+      '@fuel-ts/address': 0.96.1
+      '@fuel-ts/contract': 0.96.1
+      '@fuel-ts/crypto': 0.96.1
+      '@fuel-ts/errors': 0.96.1
+      '@fuel-ts/hasher': 0.96.1
+      '@fuel-ts/interfaces': 0.96.1
+      '@fuel-ts/math': 0.96.1
+      '@fuel-ts/merkle': 0.96.1
+      '@fuel-ts/program': 0.96.1
+      '@fuel-ts/script': 0.96.1
+      '@fuel-ts/transactions': 0.96.1
+      '@fuel-ts/utils': 0.96.1
+      '@fuel-ts/versions': 0.96.1
       bundle-require: 5.0.0(esbuild@0.24.0)
       chalk: 4.1.2
       chokidar: 3.6.0


### PR DESCRIPTION
Updates `fuels` versions to the latest

```
LICENSE:
The Fuel Support team submits this PR to help you use the fuel SDKs. It is provided "as is" 
and without warranty for any purpose. We are not participants in the project at hand. 
All the rights of this code are reserved to the authors of this repository.
```